### PR TITLE
fixed broken unit test

### DIFF
--- a/tests/unit_tests/test_routes.py
+++ b/tests/unit_tests/test_routes.py
@@ -98,6 +98,11 @@ class TestPutEndpoint(BaseRouteTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, "application/json")
+        for key in response_post.json:
+            # values for "updated" should and may differ, so ignore them in
+            # this assertion
+            if key != "updated":
+                self.assertEqual(response_post.json[key], response.json[key])
 
     def test_invalid_kml_put(self):
 


### PR DESCRIPTION
In PR https://github.com/geoadmin/service-kml/pull/14 a line was deleted from a unit test by mistake.
This line was part of the test_valid_kml_put() and asserted the equality of response_post.json and response.json.
However, since the updated timestamp was added to the responses, this assertion would have failed. So the
assertion was re-added in this PR but ignoring the updated key of the responses' jsons, as the updated timestamps
should and may differ.