### PR TITLE
BGDIINF_SB-1971: Added KML author in POST request

### DIFF
--- a/app/helpers/dynamodb.py
+++ b/app/helpers/dynamodb.py
@@ -3,11 +3,11 @@ import logging
 from flask import abort
 from flask import g
 
-import boto3
+from boto3 import resource
+from boto3.dynamodb.conditions import Key
 
 from botocore.client import Config
 from botocore.exceptions import EndpointConnectionError
-from boto3.dynamodb.conditions import Key
 
 from app.settings import AWS_DB_ENDPOINT_URL
 from app.settings import AWS_DB_REGION_NAME
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_dynamodb_resource(region, endpoint_url):
-    return boto3.resource('dynamodb', endpoint_url=endpoint_url, config=Config(region_name=region))
+    return resource('dynamodb', endpoint_url=endpoint_url, config=Config(region_name=region))
 
 
 def get_db():
@@ -40,7 +40,7 @@ class DynamoDBFilesHandler:
         self.bucket_name = bucket_name
         self.endpoint = endpoint_url
 
-    def save_item(self, kml_id, kml_admin_id, file_key, timestamp, empty=False):
+    def save_item(self, kml_id, kml_admin_id, file_key, timestamp, empty=False, author=''):
         try:
             self.table.put_item(
                 Item={
@@ -50,7 +50,8 @@ class DynamoDBFilesHandler:
                     'updated': timestamp,
                     'bucket': self.bucket_name,
                     'file_key': file_key,
-                    'empty': empty
+                    'empty': empty,
+                    'author': author
                 }
             )
         except EndpointConnectionError as error:

--- a/app/routes.py
+++ b/app/routes.py
@@ -42,6 +42,9 @@ def create_kml():
     # Get the kml file data
     kml_string, empty = validate_kml_file()
 
+    # Get the author
+    author = request.form.get('author', 'unknown')
+
     kml_admin_id = urlsafe_b64encode(uuid4().bytes).decode('utf8').replace('=', '')
     kml_id = urlsafe_b64encode(uuid4().bytes).decode('utf8').replace('=', '')
     file_key = f'{ROUTE_FILES_PREFIX}/{kml_id}'
@@ -51,7 +54,7 @@ def create_kml():
     storage.upload_object_to_bucket(file_key, kml_string)
 
     db = get_db()
-    db.save_item(kml_id, kml_admin_id, file_key, timestamp, empty)
+    db.save_item(kml_id, kml_admin_id, file_key, timestamp, empty, author)
 
     return make_response(
         jsonify(


### PR DESCRIPTION
Now in the POST request you can specify the KML author. This will allow
to differentiates KMLs created by user (map viewer) to the one created
by E2E tests.