### PR TITLE
BGDIINF_SB-1971: Disable caching for KML File on S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,4 @@ The service is configured by Environment Variable:
 | KML_STORAGE_HOST_URL | `None` | KML storage host. This can be used if the S3 storage is not on the same host as the service (e.g. local development where service runs on `localhost:5000` and storage on `localhost:9090` |
 | KML_MAX_SIZE | `2 * 1024 * 1024` | KML max size file allowed in bytes |
 | ALLOWED_DOMAINS | `.*\.geo\.admin\.ch,.*bgdi\.ch,.*\.swisstopo\.cloud` | Comma separated of domain pattern allowed in Origin header |
+| KML_FILE_CACHE_CONTROL | `no-store, max-age=0` | Cache Control header set in answer when serving the KML file. |

--- a/app/helpers/s3.py
+++ b/app/helpers/s3.py
@@ -14,6 +14,7 @@ from botocore.exceptions import EndpointConnectionError
 from app.settings import AWS_S3_BUCKET_NAME
 from app.settings import AWS_S3_ENDPOINT_URL
 from app.settings import AWS_S3_REGION_NAME
+from app.settings import KML_FILE_CACHE_CONTROL
 from app.settings import KML_FILE_CONTENT_TYPE
 
 logger = logging.getLogger(__name__)
@@ -79,7 +80,8 @@ class S3FileHandling:
                 Body=data,
                 Bucket=AWS_S3_BUCKET_NAME,
                 Key=file_key,
-                ContentType=KML_FILE_CONTENT_TYPE
+                ContentType=KML_FILE_CONTENT_TYPE,
+                CacheControl=KML_FILE_CACHE_CONTROL
             )
         except EndpointConnectionError as error:
             logger.exception('Failed to connect to S3: %s', error)

--- a/app/settings.py
+++ b/app/settings.py
@@ -25,6 +25,10 @@ MB = 1024 * 1024
 KML_MAX_SIZE = int(os.getenv('KML_MAX_SIZE', str(2 * MB)))
 
 KML_FILE_CONTENT_TYPE = 'application/vnd.google-earth.kml+xml'
+# No cache behavior taken from
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#preventing_caching
+NO_CACHE = 'no-store, max-age=0'
+KML_FILE_CACHE_CONTROL = os.getenv('KML_FILE_CACHE_CONTROL', NO_CACHE)
 
 ALLOWED_DOMAINS = os.getenv(
     'ALLOWED_DOMAINS', r'.*\.geo\.admin\.ch,.*bgdi\.ch,.*\.swisstopo\.cloud'


### PR DESCRIPTION
Disabling the cache for KML file will avoid issue when modifying shared
kml drawing. The cache control can/could also be changed via environment
variable if needed.