### PR TITLE
BGDIINF_SB-2027: Add cache-control header

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,5 @@ The service is configured by Environment Variable:
 | FORWARED_ALLOW_IPS | `*` | Sets the gunicorn `forwarded_allow_ips`. See [Gunicorn Doc](https://docs.gunicorn.org/en/stable/settings.html#forwarded-allow-ips). This setting is required in order to `secure_scheme_headers` to work. |
 | FORWARDED_PROTO_HEADER_NAME | `X-Forwarded-Proto` | Sets gunicorn `secure_scheme_headers` parameter to `{${FORWARDED_PROTO_HEADER_NAME}: 'https'}`. This settings is required in order to generate correct URLs in the service responses. See [Gunicorn Doc](https://docs.gunicorn.org/en/stable/settings.html#secure-scheme-headers). |
 | SCRIPT_NAME | `''` | If the service is behind a reverse proxy and not served at the root, the route prefix must be set in `SCRIPT_NAME`. |
+| CACHE_CONTROL | `no-cache, no-store, must-revalidate` | Cache Control header value of the GET endpoint(s) |
+| CACHE_CONTROL_4XX | `public, max-age=3600` | Cache Control header for 4XX responses |

--- a/app/settings.py
+++ b/app/settings.py
@@ -30,3 +30,6 @@ ALLOWED_DOMAINS = os.getenv('ALLOWED_DOMAINS', r'.*').split(',')
 ALLOWED_DOMAINS_PATTERN = '({})'.format('|'.join(ALLOWED_DOMAINS))
 
 SCRIPT_NAME = os.getenv('SCRIPT_NAME', '')
+
+CACHE_CONTROL = os.getenv('CACHE_CONTROL', 'no-cache, no-store, must-revalidate')
+CACHE_CONTROL_4XX = os.getenv('CACHE_CONTROL_4XX', 'public, max-age=3600')

--- a/tests/unit_tests/test_routes.py
+++ b/tests/unit_tests/test_routes.py
@@ -20,6 +20,7 @@ class CheckerTests(BaseRouteTestCase):
     def test_checker(self):
         response = self.app.get(url_for('checker'), headers=self.origin_headers["allowed"])
         self.assertEqual(response.status_code, 200)
+        self.assertNotIn('Cache-Control', response.headers)
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json, {"message": "OK", "success": True, "version": APP_VERSION})
 
@@ -92,6 +93,10 @@ class TestGetEndpoint(BaseRouteTestCase):
             url_for('get_kml_metadata', kml_id=id_to_fetch), headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 200)
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('no-cache', response.headers['Cache-Control'])
+        self.assertIn('Expire', response.headers)
+        self.assertEqual(response.headers['Expire'], '0')
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(stored_geoadmin_link, response.json['links']['kml'])
         self.assertEqual(stored_kml_admin_link, response.json['links']['self'])
@@ -106,6 +111,10 @@ class TestGetEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 200, msg=f'Request failed: {response.json}')
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('no-cache', response.headers['Cache-Control'])
+        self.assertIn('Expire', response.headers)
+        self.assertEqual(response.headers['Expire'], '0')
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(stored_geoadmin_link, response.json['links']['kml'])
         self.assertEqual(stored_kml_admin_link, response.json['links']['self'])
@@ -116,6 +125,9 @@ class TestGetEndpoint(BaseRouteTestCase):
             url_for('get_kml_metadata_by_admin_id'), headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('max-age=3600', response.headers['Cache-Control'])
+        self.assertNotIn('Expire', response.headers)
         self.assertEqual(response.content_type, 'application/json')
         self.assertIn('error', response.json, msg=f'error not found in answer: {response.json}')
         self.assertIn(
@@ -131,6 +143,9 @@ class TestGetEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 404)
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('max-age=3600', response.headers['Cache-Control'])
+        self.assertNotIn('Expire', response.headers)
         self.assertEqual(response.content_type, 'application/json')
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(
@@ -143,6 +158,9 @@ class TestGetEndpoint(BaseRouteTestCase):
             url_for('get_kml_metadata', kml_id=id_to_fetch), headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 404)
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('max-age=3600', response.headers['Cache-Control'])
+        self.assertNotIn('Expire', response.headers)
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(
             response.json['error']['message'], f'Could not find {id_to_fetch} within the database.'
@@ -154,6 +172,9 @@ class TestGetEndpoint(BaseRouteTestCase):
             url_for('get_kml_metadata', kml_id=id_to_fetch), headers=self.origin_headers["bad"]
         )
         self.assertEqual(response.status_code, 403)
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('max-age=3600', response.headers['Cache-Control'])
+        self.assertNotIn('Expire', response.headers)
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json["error"]["message"], "Permission denied")
 


### PR DESCRIPTION
By default we don't want to cache the requests (except for 4xx) as the
resource might change due to POST/PUT/DELETE requests.