### PR TITLE
Don't add CORS to /checker

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -35,6 +35,10 @@ def log_route():
 # Add CORS Headers to all request
 @app.after_request
 def add_cors_header(response):
+    # Do not add CORS header to internal /checker endpoint.
+    if request.endpoint == 'checker':
+        return response
+
     if (
         'Origin' in request.headers and
         re.match(ALLOWED_DOMAINS_PATTERN, request.headers['Origin'])
@@ -52,7 +56,7 @@ def add_cors_header(response):
 @app.after_request
 def add_cache_control_header(response):
     # For /checker route we let the frontend proxy decide how to cache it.
-    if request.method == 'GET' and request.path != url_for('checker'):
+    if request.method == 'GET' and request.endpoint != 'checker':
         if response.status_code >= 400:
             response.headers.set('Cache-Control', CACHE_CONTROL_4XX)
         else:


### PR DESCRIPTION
This is an internal endpoint used by k8s.