### PR TITLE
BGDIINF_SB-2046: Corrected allowed method CORS header

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -7,3 +7,4 @@ AWS_DB_REGION_NAME=eu-central-1
 AWS_DB_TABLE_NAME=test-db
 AWS_DB_ENDPOINT_URL=http://localhost:8080
 KML_STORAGE_HOST_URL=http://localhost:9090/test-bucket
+ALLOWED_DOMAINS=.*localhost,.*admin\.ch,.*bgdi\.ch

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -47,7 +47,7 @@ def add_cors_header(response):
 
     # Always add the allowed methods.
     response.headers.set(
-        'Access-Control-Allow-Methods', ', '.join(get_registered_method(app, request.endpoint))
+        'Access-Control-Allow-Methods', ', '.join(get_registered_method(app, request.url_rule))
     )
     response.headers.set('Access-Control-Allow-Headers', '*')
     return response

--- a/app/helpers/utils.py
+++ b/app/helpers/utils.py
@@ -160,7 +160,7 @@ def get_kml_file_link(file_key):
     return f'{request.host_url}{file_key}'
 
 
-def get_registered_method(app, endpoint):
+def get_registered_method(app, url_rule):
     '''Returns the list of registered method for the given endpoint'''
 
     # The list of registered method is taken from the werkzeug.routing.Rule. A Rule object
@@ -168,8 +168,12 @@ def get_registered_method(app, endpoint):
     # missing then all methods are allowed.
     # See https://werkzeug.palletsprojects.com/en/2.0.x/routing/#werkzeug.routing.Rule
     all_methods = ['GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'DELETE']
-    return list(
+    return set(
         chain.from_iterable(
-            [r.methods if r.methods else all_methods for r in app.url_map.iter_rules(endpoint)]
+            [
+                r.methods if r.methods else all_methods
+                for r in app.url_map.iter_rules()
+                if r.rule == str(url_rule)
+            ]
         )
     )

--- a/tests/unit_tests/test_routes.py
+++ b/tests/unit_tests/test_routes.py
@@ -36,7 +36,7 @@ class TestPostEndpoint(BaseRouteTestCase):
     def test_valid_kml_post(self):
         response = self.create_test_kml()
         self.assertEqual(response.status_code, 201)
-        self.assertCors(response, ['POST', 'OPTIONS'])
+        self.assertCors(response, ['GET', 'HEAD', 'POST', 'OPTIONS'])
         self.assertEqual(response.content_type, "application/json")  # pylint: disable=no-member
         self.compare_kml_contents(response, self.kml_dict["valid"])
 
@@ -48,7 +48,7 @@ class TestPostEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 400)
-        self.assertCors(response, ['POST', 'OPTIONS'])
+        self.assertCors(response, ['GET', 'HEAD', 'POST', 'OPTIONS'])
         self.assertEqual(response.json['error']['message'], 'Invalid kml file')
         self.assertEqual(response.content_type, "application/json")
 
@@ -60,7 +60,7 @@ class TestPostEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["bad"]
         )
         self.assertEqual(response.status_code, 403)
-        self.assertCors(response, ['POST', 'OPTIONS'], check_origin=False)
+        self.assertCors(response, ['GET', 'HEAD', 'POST', 'OPTIONS'], check_origin=False)
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json["error"]["message"], "Permission denied")
 
@@ -72,7 +72,7 @@ class TestPostEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 415)
-        self.assertCors(response, ['POST', 'OPTIONS'])
+        self.assertCors(response, ['GET', 'HEAD', 'POST', 'OPTIONS'])
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json["error"]["message"], "Unsupported Media Type")
 
@@ -83,7 +83,7 @@ class TestPostEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 415)
-        self.assertCors(response, ['POST', 'OPTIONS'])
+        self.assertCors(response, ['GET', 'HEAD', 'POST', 'OPTIONS'])
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json["error"]["message"], "Unsupported KML media type")
 
@@ -98,7 +98,7 @@ class TestGetEndpoint(BaseRouteTestCase):
             url_for('get_kml_metadata', kml_id=id_to_fetch), headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 200)
-        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'])
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'])
         self.assertIn('Cache-Control', response.headers)
         self.assertIn('no-cache', response.headers['Cache-Control'])
         self.assertIn('Expire', response.headers)
@@ -117,7 +117,7 @@ class TestGetEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 200, msg=f'Request failed: {response.json}')
-        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'])
+        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS', 'POST'])
         self.assertIn('Cache-Control', response.headers)
         self.assertIn('no-cache', response.headers['Cache-Control'])
         self.assertIn('Expire', response.headers)
@@ -132,7 +132,7 @@ class TestGetEndpoint(BaseRouteTestCase):
             url_for('get_kml_metadata_by_admin_id'), headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 400)
-        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'])
+        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS', 'POST'])
         self.assertIn('Cache-Control', response.headers)
         self.assertIn('max-age=3600', response.headers['Cache-Control'])
         self.assertNotIn('Expire', response.headers)
@@ -151,7 +151,7 @@ class TestGetEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 404)
-        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'])
+        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS', 'POST'])
         self.assertIn('Cache-Control', response.headers)
         self.assertIn('max-age=3600', response.headers['Cache-Control'])
         self.assertNotIn('Expire', response.headers)
@@ -167,7 +167,7 @@ class TestGetEndpoint(BaseRouteTestCase):
             url_for('get_kml_metadata', kml_id=id_to_fetch), headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 404)
-        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'])
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'])
         self.assertIn('Cache-Control', response.headers)
         self.assertIn('max-age=3600', response.headers['Cache-Control'])
         self.assertNotIn('Expire', response.headers)
@@ -182,7 +182,7 @@ class TestGetEndpoint(BaseRouteTestCase):
             url_for('get_kml_metadata', kml_id=id_to_fetch), headers=self.origin_headers["bad"]
         )
         self.assertEqual(response.status_code, 403)
-        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'], check_origin=False)
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'], check_origin=False)
         self.assertIn('Cache-Control', response.headers)
         self.assertIn('max-age=3600', response.headers['Cache-Control'])
         self.assertNotIn('Expire', response.headers)
@@ -203,7 +203,7 @@ class TestPutEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 200)
-        self.assertCors(response, ['PUT', 'OPTIONS'])
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'])
         self.assertEqual(response.content_type, "application/json")
         for key in self.sample_kml:
             # values for "updated" should and may differ, so ignore them in
@@ -233,7 +233,7 @@ class TestPutEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 400)
-        self.assertCors(response, ['PUT', 'OPTIONS'])
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'])
         self.assertEqual(response.json['error']['message'], 'Invalid kml file')
         self.assertEqual(response.content_type, "application/json")
 
@@ -250,7 +250,7 @@ class TestPutEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 404)
-        self.assertCors(response, ['PUT', 'OPTIONS'])
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'])
         self.assertEqual(
             response.json['error']['message'],
             f'Could not find {id_to_update} within the database.'
@@ -268,7 +268,7 @@ class TestPutEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["bad"]
         )
         self.assertEqual(response.status_code, 403)
-        self.assertCors(response, ['PUT', 'OPTIONS'], check_origin=False)
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'], check_origin=False)
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json["error"]["message"], "Permission denied")
 
@@ -281,7 +281,7 @@ class TestPutEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["bad"]
         )
         self.assertEqual(response.status_code, 403)
-        self.assertCors(response, ['PUT', 'OPTIONS'], check_origin=False)
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'], check_origin=False)
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json["error"]["message"], "Permission denied")
 
@@ -294,7 +294,7 @@ class TestPutEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["bad"]
         )
         self.assertEqual(response.status_code, 403)
-        self.assertCors(response, ['PUT', 'OPTIONS'], check_origin=False)
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'], check_origin=False)
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json["error"]["message"], "Permission denied")
 
@@ -314,7 +314,7 @@ class TestDeleteEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 200)
-        self.assertCors(response, ['DELETE', 'OPTIONS'])
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'])
         self.assertEqual(response.content_type, "application/json")
 
         response = self.app.get(
@@ -335,7 +335,7 @@ class TestDeleteEndpoint(BaseRouteTestCase):
         )
 
         self.assertEqual(response.status_code, 404)
-        self.assertCors(response, ['DELETE', 'OPTIONS'])
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'])
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(
             response.json['error']['message'],
@@ -352,7 +352,7 @@ class TestDeleteEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["bad"]
         )
         self.assertEqual(response.status_code, 403)
-        self.assertCors(response, ['DELETE', 'OPTIONS'], check_origin=False)
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'], check_origin=False)
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json["error"]["message"], "Permission denied")
 
@@ -366,7 +366,7 @@ class TestDeleteEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 403)
-        self.assertCors(response, ['DELETE', 'OPTIONS'], check_origin=False)
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'], check_origin=False)
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json["error"]["message"], "Permission denied")
 
@@ -379,7 +379,7 @@ class TestDeleteEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 403)
-        self.assertCors(response, ['DELETE', 'OPTIONS'], check_origin=False)
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'], check_origin=False)
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json["error"]["message"], "Permission denied")
 
@@ -393,6 +393,6 @@ class TestDeleteEndpoint(BaseRouteTestCase):
             headers=self.origin_headers["allowed"]
         )
         self.assertEqual(response.status_code, 415)
-        self.assertCors(response, ['DELETE', 'OPTIONS'])
+        self.assertCors(response, ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT'])
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json["error"]["message"], "Unsupported Media Type")


### PR DESCRIPTION
The allowed method in CORS header where not correct, the list contained
only the methods for the endpoint (methods registered by the python
route function). For example the path GET /admin/<kml_id> returned the
list GET, HEAD, OPTIONS, but the PUT and DELETE where missing because
they are part of other Flask endpoints.

Also added the ALLOWED_DOMAINS in .env.default in order to simplify the
e2e test with localhost.