### PR TITLE
Add PR auto Title Workflow and updated PR labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     types:
       - opened
+      - reopened
+      - synchronize
       - edited
+
 
 jobs:
   pr-labeler:

--- a/.github/workflows/pr-semver-release-title.yml
+++ b/.github/workflows/pr-semver-release-title.yml
@@ -1,0 +1,15 @@
+name: PR New SemVer Release Auto Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+    branches:
+      - master
+
+jobs:
+  pr-auto-title:
+    uses: geoadmin/.github/.github/workflows/pr-semver-release-title.yml@master


### PR DESCRIPTION
The PR Labeler cause sometimes trouble where a PR is waiting on the action
results while the action hasn't been triggered. Therefore I try to add the
reopened and synchronize events.