### PR TITLE
BGDIINF_SB-2346: Only check the kml file size and not the payload size

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -14,11 +14,9 @@ from app import app
 from app.helpers.dynamodb import get_db
 from app.helpers.s3 import get_storage
 from app.helpers.utils import get_kml_file_link
-from app.helpers.utils import validate_content_length
 from app.helpers.utils import validate_content_type
 from app.helpers.utils import validate_kml_file
 from app.helpers.utils import validate_permissions
-from app.settings import KML_MAX_SIZE
 from app.settings import SCRIPT_NAME
 from app.version import APP_VERSION
 
@@ -35,7 +33,6 @@ def checker():
 
 @app.route('/admin', methods=['POST'])
 @validate_content_type("multipart/form-data")
-@validate_content_length(KML_MAX_SIZE)
 def create_kml():
     # Get the kml file data
     kml_string_gzip, empty = validate_kml_file()
@@ -124,7 +121,6 @@ def get_kml_metadata(kml_id):
 
 @app.route('/admin/<kml_id>', methods=['PUT'])
 @validate_content_type("multipart/form-data")
-@validate_content_length(KML_MAX_SIZE)
 def update_kml(kml_id):
     db = get_db()
 

--- a/tests/unit_tests/base.py
+++ b/tests/unit_tests/base.py
@@ -198,7 +198,8 @@ class BaseRouteTestCase(unittest.TestCase):
         expected_kml_path = f'./tests/samples/{expected_kml_file}'
         # read the expected kml file
         with open(expected_kml_path, 'rb') as fd:
-            expected_kml = decompress_if_gzipped(fd).decode('utf-8')
+            content = fd.read()
+            expected_kml = decompress_if_gzipped(content).decode('utf-8')
         kml_id = response.json['id']
         item = self.dynamodb.Table(AWS_DB_TABLE_NAME).get_item(Key={
             'kml_id': kml_id
@@ -230,7 +231,7 @@ class BaseRouteTestCase(unittest.TestCase):
             else:
                 self.fail(f'S3 client error: {error}')
 
-        body = decompress_if_gzipped((obj['Body']))
+        body = decompress_if_gzipped((obj['Body'].read()))
         self.assertEqual(body.decode('utf-8'), expected_kml)
 
     def get_s3_object(self, file_key):

--- a/tests/unit_tests/test_routes.py
+++ b/tests/unit_tests/test_routes.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import uuid
 from datetime import timedelta
+from unittest.mock import patch
 
 from flask import url_for
 
@@ -48,6 +49,19 @@ class TestPostEndpoint(BaseRouteTestCase):
         self.assertCors(response, ['GET', 'HEAD', 'POST', 'OPTIONS'])
         self.assertEqual(response.content_type, "application/json")  # pylint: disable=no-member
         self.assertKml(response, kml_file)
+
+    @patch('app.helpers.utils.KML_MAX_SIZE', 10)
+    def test_too_big_kml_post(self):
+        kml_file = 'valid-kml.xml'
+        response = self.app.post(
+            url_for('create_kml'),
+            data=prepare_kml_payload(kml_file=kml_file),
+            content_type="multipart/form-data",
+            headers=self.origin_headers["allowed"]
+        )
+        self.assertEqual(response.status_code, 413)
+        self.assertCors(response, ['GET', 'HEAD', 'POST', 'OPTIONS'])
+        self.assertEqual(response.content_type, "application/json")  # pylint: disable=no-member
 
     def test_invalid_kml_post(self):
         response = self.app.post(


### PR DESCRIPTION
The payload size can change depending on the method POST or PUT and also
depending on the client that sets the mutlipart boundary string.

Therefore to avoid issue with kml file that might once be created and thereafter
not be edited anymore due to the overhead of the multipart payload we changed
the logic by checking the size of the file instead of the payload.