### PR TITLE
BGDIINF_SB-2346: Avoid memory starting

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -14,6 +14,7 @@ from app import app
 from app.helpers.dynamodb import get_db
 from app.helpers.s3 import get_storage
 from app.helpers.utils import get_kml_file_link
+from app.helpers.utils import validate_content_length
 from app.helpers.utils import validate_content_type
 from app.helpers.utils import validate_kml_file
 from app.helpers.utils import validate_permissions
@@ -32,6 +33,7 @@ def checker():
 
 
 @app.route('/admin', methods=['POST'])
+@validate_content_length()
 @validate_content_type("multipart/form-data")
 def create_kml():
     # Get the kml file data
@@ -120,6 +122,7 @@ def get_kml_metadata(kml_id):
 
 
 @app.route('/admin/<kml_id>', methods=['PUT'])
+@validate_content_length()
 @validate_content_type("multipart/form-data")
 def update_kml(kml_id):
     db = get_db()


### PR DESCRIPTION
The current kml file size limit doesn't prevent a memory starving issue
as this will first load the file into memory before doing the size check.

So we add a payload check with a high enough multipart/form-data overhead before
reading/uploading the data, so the request can be rejected before starving
the memory.

Note it is not safe to use the KML_MAX_SIZE as the payload max size, because
the payload overhead size changes between POST and PUT, so we might create files
but not modified them anymore even if the size did not changed.