### PR TITLE
BGDIINF_SB-2648: Made the gunicorn worker tmp dir configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,4 @@ The service is configured by Environment Variable:
 | SCRIPT_NAME | `''` | If the service is behind a reverse proxy and not served at the root, the route prefix must be set in `SCRIPT_NAME`. |
 | CACHE_CONTROL | `no-cache, no-store, must-revalidate` | Cache Control header value of the GET endpoint(s) |
 | CACHE_CONTROL_4XX | `public, max-age=3600` | Cache Control header for 4XX responses |
+| GUNICORN_WORKER_TMP_DIR | `/tmp/gunicorn_workers` | Gunicorn worker tmp directory. :warning: This directory should be on **TMPFS** for better performance. |

--- a/wsgi.py
+++ b/wsgi.py
@@ -50,6 +50,7 @@ if __name__ == '__main__':
         'timeout': 60,
         'logconfig_dict': get_logging_cfg(),
         'forwarded_allow_ips': os.getenv('FORWARED_ALLOW_IPS', '*'),
+        'worker_tmp_dir': os.getenv("GUNICORN_WORKER_TMP_DIR", "/tmp/gunicorn_workers"),
         'secure_scheme_headers':
             {
                 os.getenv('FORWARDED_PROTO_HEADER_NAME', 'X-Forwarded-Proto').upper(): 'https'


### PR DESCRIPTION
This tmp dir should be on TMPFS for better performance.