### PR TITLE
PB 887 Fix dockerfile to use pipenv sync instead of install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ RUN groupadd -r geoadmin && useradd -u 1000 -r -s /bin/false -g geoadmin geoadmi
 RUN pip3 install pipenv \
     && pipenv --version
 
-COPY Pipfile* /tmp/
-RUN cd /tmp && \
-    pipenv install --system --deploy --ignore-pipfile
+COPY Pipfile.lock /tmp/
+RUN cd /tmp && pipenv sync
 
 WORKDIR /app
 COPY --chown=geoadmin:geoadmin ./ /app/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See also [Git Flow - Versioning](https://github.com/geoadmin/doc-guidelines/blob
 
 ### Make Dependencies
 
-The **Make** targets assume you have **python3.11**, **pipenv**, **bash**, **curl**, **tar**, **docker** and **docker-compose** installed.
+The **Make** targets assume you have **python3.11**, **pipenv**, **bash**, **curl**, **tar**, **docker** and **docker-compose-plugin** installed.
 
 ### Setting up to work
 
@@ -75,7 +75,7 @@ The other services that are used (DynamoDB local and [MinIO](https://www.min.io)
 Starting DynamoDB local and MinIO is done with a simple
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 in the source root folder. Make sure to run `make dev` before to ensure the necessary folders `.volumes/*` are in place. These folders are mounted in the services and allow data persistency over restarts of the containers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   s3:
     image: minio/minio


### PR DESCRIPTION
Noticing that the build fail on my [last PR](https://github.com/geoadmin/service-kml/pull/72) I did a little digging on why this is happening. I was able to reproduce the problem locally (`docker build . `). The offending line is the one where `pipenv` installs the dependencies.

I compared the `Dockerfile` to the one in `service-stac` and noticed that in `service-stac` the command `sync` is used together with the `Pipfile.lock` file, which to me makes total sense, so I changed it here too.

Now since I have no clue about `service-kml` I don't know if this is a good idea and how to test if it still works. 