### PR TITLE
PB-1849: update from Buster to Bookworm.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster AS base
+FROM python:3.11-slim-bookworm AS base
 
 ENV USER=geoadmin
 ENV GROUP=geoadmin


### PR DESCRIPTION
Debian Buster stopped receiving security updates on [2022-06-30](https://www.debian.org/releases/buster/). It was removed from the main Debian mirror some time between [2025-07-09](https://web.archive.org/web/20250709234633/https://ftp.debian.org/debian/dists/) and 2025-07-15. This means that any build we have that is based on a Buster image and that attempts to run "apt-get" fails.

This change updates the [base image](https://hub.docker.com/_/python) from Buster to [Bookworm](https://www.debian.org/releases/bookworm/).
